### PR TITLE
Fix ZipFolder call. Tweak docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ___
 ## Setup instructions
 
 1. Clone repository and run `npm install`
-2. ZIP contents of the folder (not the folder itself)
+2. ZIP contents of the folder (not the folder itself, and be sure not to include the .git folder)
 3. Create AWS Lambda function
    - Choose Node.js 8.10 runtime
    - Choose an existing role or create a new one and make sure it has write permissions to the S3 bucket that you want to back up to

--- a/README.md
+++ b/README.md
@@ -37,4 +37,5 @@ ___
 | MONGO_REPLICA_SET | Name of the replica set in the form `clustername-shard-0` | Yes |
 | MONGO_CLUSTER_SHARD | Name of the cluster shards in the form `clustername-shard-00-00-xxxxx.mongodb.net,clustername-shard-00-01-xxxxx.mongodb.net,clustername-shard-00-02-xxxxx.mongodb.net` | Yes |
 | S3_BUCKET | Name of the S3 bucket | Yes |
+| S3_STORAGE_CLASS | S3 storage class | No, default is Standard |
 | DATE_FORMAT | Backup file name is in the format `[MONGO_DB_NAME]_[DATE_FORMAT]`. For possible date formatting options, refer to [DAY.JS](https://github.com/iamkun/dayjs/blob/master/docs/en/API-reference.md#format) | No. Default is `YYYYMMDD_HHmmss` |

--- a/index.js
+++ b/index.js
@@ -18,7 +18,9 @@ const replicaSet = process.env.MONGO_REPLICA_SET;
 const clusterShard = process.env.MONGO_CLUSTER_SHARD;
 // S3
 const bucketName = process.env.S3_BUCKET;
-const s3bucket = new AWS.S3({ params: { Bucket: bucketName } });
+const storageClass = process.env.S3_STORAGE_CLASS || "STANDARD";
+const s3bucket = new AWS.S3({ params: { Bucket: bucketName, StorageClass: storageClass } });
+
 const dateFormat = process.env.DATE_FORMAT || 'YYYYMMDD_HHmmss';
 
 module.exports.handler = function(event, context, cb) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const AWS = require('aws-sdk');
 const fs = require('fs');
 const url = require('url');
 const dayjs = require('dayjs');
-const zipFolder = require('zip-a-folder');
+const ZipFolder = require('zip-a-folder');
 const exec = require('child_process').exec;
 
 // ENVIRONMENT VARIABLES
@@ -36,7 +36,7 @@ module.exports.handler = function(event, context, cb) {
         return;
       }
 
-      zipFolder(folderName, filePath, function(err) {
+      ZipFolder.zipFolder(folderName, filePath, function(err) {
         if (err) {
           console.log('ZIP failed: ', err);
         } else {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "dayjs": "^1.7.8",
-    "zip-a-folder": "0.0.6"
+    "zip-a-folder": "0.0.7"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Hi! I absolutely love this project - great work.

This PR: 

- fixes a small but curious bug with the zip-a-folder library. That project exports a class, but you were calling the class itself without new, when it seems you meant to call a static method on the class.  I did upgrade the library to the latest 0.0.7, from 0.0.6, but the error was the same either way. Not sure how this code ever worked, but this PR fixes it.  (edit - I see now from the git logs that you were using the npm util `zip-folder` but changed to `zip-a-folder` - seems the new one has a slightly different api)

- adds a storage class option (with docs in readme), to control which S3 storage class to use (defaults to STANDARD, of course)

- tweaks the readme to remind users not to zip the .git folder, since that'll likely put them over 10MB.

Thanks again for making this! 