### PR TITLE
Update package.json, add aws-sdk dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "archiver": "5.0.0",
+    "aws-sdk": "^2.1423.0",
     "dayjs": "1.8.34"
   },
   "devDependencies": {},


### PR DESCRIPTION
I just add `aws-sdk` dependency into package.json, because when I used the original source I got an error

```
"errorType": "Runtime.ImportModuleError",
    "errorMessage": "Error: Cannot find module 'aws-sdk'\nRequire stack:\n- /var/task/index.js\n- /var/runtime/index.mjs"
```